### PR TITLE
Add SDO images and retrieval script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+data/** filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -1,51 +1,106 @@
 # Nasa Space Apps 2023 - Met Office, Exeter
+
 ![NASA SpaceApps Logo](nasa_spaceapps_logo.png)
-## Resources:
-- [2023 challenges](https://www.spaceappschallenge.org/2023/challenges/)
-- [Met Office blog](https://blog.metoffice.gov.uk/2023/09/07/nasa-space-apps-challenge-is-coming-to-exeter/)
 
-
-## Space weather-y challenges
-
-1. Oracle of DSCOVR
-2. Magnetic reconnection
-3. Immersed in the sounds of space
-4. ??? Helio Big Year
-
-## Creche-compatible challenges
-
-1. Eclipses: Perspective
-2. Work of SARt
-3. Video on Artemis?
-4. Open science storytelling
+* [Introduction](#introduction)
+* [Resources](#resources)
+  * [Challenges related to space weather, and resources](#challenges-related-to-space-weather-and-resources)
+  * [Creche-compatible challenges](#creche-compatible-challenges)
+  * [Introduction to Python for Environmental Science](#introduction-to-python-for-environmental-science)
 
 ## Introduction
 
-This series of tutorials on technical and data resources for NASA Space Apps Challenge 2023, hosted in Exeter by the Joint Centre of Excellence in Environmental Intelligence and TechExeter.
+This repository provides a series of tutorials on technical and data resources
+for NASA Space Apps Challenge 2023, hosted in Exeter by the Joint Centre of Excellence
+in Environmental Intelligence and TechExeter.
+
+## Resources
+
+* [2023 challenges](https://www.spaceappschallenge.org/2023/challenges/)
+* [Met Office blog](https://blog.metoffice.gov.uk/2023/09/07/nasa-space-apps-challenge-is-coming-to-exeter/)
+* [Exeter event (schedule, teams)](https://www.spaceappschallenge.org/2023/locations/exeter/)
+
+### Challenges related to space weather, and resources
+
+1. [Develop the Oracle of DSCOVR](https://www.spaceappschallenge.org/2023/challenges/develop-the-oracle-of-dscovr/)
+   1. 2 teams chose
+      1. [BANSSAB](https://www.spaceappschallenge.org/2023/find-a-team/banssab/)
+      2. [Solar Storm](https://www.spaceappschallenge.org/2023/find-a-team/solar-storm/)
+2. [Immersed in the Sounds of Space](https://www.spaceappschallenge.org/2023/challenges/immersed-in-the-sounds-of-space/)
+   1. 1 team chose
+      1. [Solar Sounds](https://www.spaceappschallenge.org/2023/find-a-team/solar-sounds/)
+         1. Local event winners!
+         2. *Contained members of pre-event team [Solar Audible Experience](https://www.spaceappschallenge.org/2023/find-a-team/solar-sounds/)*
+   2. Data: Solar Dynamics Observatory imagery in [`data/immersed_sounds_space/SDO/`](data/immersed_sounds_space/SDO/)
+      1. Attribute as follows: ["Courtesy of NASA/SDO and the AIA, EVE, and HMI science teams."](https://sdo.gsfc.nasa.gov/data/rules.php)
+      2. Data retrieval script: [`bin/download_sdo_data`](bin/download_sdo_data)
+3. [Magnetic Reconnection](https://www.spaceappschallenge.org/2023/challenges/magnetic-reconnection/)
+   1. *No teams participated locally*
+   2. *No resources created*
+4. Potentially: [Winning the Helio Big Year with Joy, Curiosity, and Science!](https://www.spaceappschallenge.org/2023/challenges/winning-the-helio-big-year-with-joy-curiosity-and-science/)
+   1. *No teams participated locally*
+   2. *No resources created*
+
+### Creche-compatible challenges
+
+The creche could possibly come up with some activities linked with these challenges:
+
+1. [Eclipses: Perspective is Everything](https://www.spaceappschallenge.org/2023/challenges/eclipses-perspective-is-everything/)
+   1. Get kids to make a game for kids to explain why not whole Earth can see given eclipse
+2. [Create a Work of SARt (Synthetic Aperture Radar Art)](https://www.spaceappschallenge.org/2023/challenges/create-a-work-of-sart-synthetic-aperture-radar-art/)
+   1. Craft activities - interpret SAR imagery with crayons, glitter, glue, ...
+3. [Artemis II and You!](https://www.spaceappschallenge.org/2023/challenges/artemis-ii-and-you/)
+   1. Get kids to create a video?
+4. [Open Science Storytelling](https://www.spaceappschallenge.org/2023/challenges/open-science-storytelling/)
+   1. Find a case; get children to come up with a story about it
 
 ### Introduction to Python for Environmental Science
 
-Learn about useful Python packages for working with environmental datasets and work through some basic examples for loading and exploring different types of data.
+*The following guidance is taken from the [bootcamp run before NASA Space Apps 2022](https://github.com/informatics-lab/spaceapps-2022-mo-bootcamp).*
+*No bootcamp was run in 2023.*
+*Nevertheless, cross-linking the previous guidance to flag resources available*
+*at the link above to help with Python and environment management*
 
-### Machine Learning with Weather Data
+Learn about useful Python packages for working with environmental datasets and work
+through some basic examples for loading and exploring different types of data.
 
-A brief introduction to machine learning and have the opportunity to work through a simple (cloud computing) example, specifically using some readily available weather data.
+#### Machine Learning with Weather Data
 
-### Introduction to Weather and Climate Datasets
+A brief introduction to machine learning and have the opportunity to work through
+a simple (cloud computing) example, specifically using some readily available weather
+data.
 
-A brief overview of the types of data we have available within the Met Office. These datasets are open source, you'll have the oppertunity download and explore this data through the example notebooks provided. This will give you the tools to explore weather and climate data yourself.
+#### Introduction to Weather and Climate Datasets
+
+A brief overview of the types of data we have available within the Met Office.
+These datasets are open source, you'll have the oppertunity download and explore
+this data through the example notebooks provided.
+This will give you the tools to explore weather and climate data yourself.
 
 ______________________________________________________________________
 
-We will assume you have some experience with programming langauges and ideally have a little bit of knowledge of python. There are a lot of excellent resources on the internet for learning python. This short series of tutorials condenses the most important parts for working specifically with enviromental datasets and provides an overview of tools to make this easier. For a more in depth understanding of python, exploring these exellent tutorials is recommended:
+We will assume you have some experience with programming langauges and ideally have a
+little bit of knowledge of python.
+There are a lot of excellent resources on the internet for learning python.
+This short series of tutorials condenses the most important parts for working
+specifically with enviromental datasets and provides an overview of tools to make
+this easier.
+For a more in depth understanding of python, exploring these exellent tutorials is
+recommended:
 
-- Software Carpentry: https://swcarpentry.github.io/python-novice-inflammation/index.html
-- DataCamp: https://www.datacamp.com/courses/intro-to-python-for-data-science
+- Software Carpentry: <https://swcarpentry.github.io/python-novice-inflammation/index.html>
+- DataCamp: <https://www.datacamp.com/courses/intro-to-python-for-data-science>
 
-### Python environment set up
-Some of these tutorials require some python package management, we have done this through [Conda](https://docs.conda.io/projects/conda/en/latest/). If you don't have Conda, [install miniconda here](https://docs.conda.io/en/latest/miniconda.html). If you prefer other package management methods please feel free to use them. More information about package management for each session will be contained in the README of that folder.
+#### Python environment set up
 
-### Acknowledgements
+Some of these tutorials require some python package management, we have done this
+through [Conda](https://docs.conda.io/projects/conda/en/latest/).
+If you don't have Conda, [install miniconda here](https://docs.conda.io/en/latest/miniconda.html).
+If you prefer other package management methods please feel free to use them.
+More information about package management for each session will be contained in the
+README of that folder.
+
+#### Acknowledgements
 
 Development of these tutorials was funded by the [Joint Centre for Excellence in Environmental Intelligence](https://jceei.org/).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 * [Introduction](#introduction)
 * [Resources](#resources)
-  * [Challenges related to space weather, and resources](#challenges-related-to-space-weather-and-resources)
+  * [Challenges related to space weather, resources, and teams](#challenges-related-to-space-weather-resources-and-teams)
   * [Creche-compatible challenges](#creche-compatible-challenges)
   * [Introduction to Python for Environmental Science](#introduction-to-python-for-environmental-science)
 
@@ -18,19 +18,23 @@ in Environmental Intelligence and TechExeter.
 
 * [2023 challenges](https://www.spaceappschallenge.org/2023/challenges/)
 * [Met Office blog](https://blog.metoffice.gov.uk/2023/09/07/nasa-space-apps-challenge-is-coming-to-exeter/)
-* [Exeter event (schedule, teams)](https://www.spaceappschallenge.org/2023/locations/exeter/)
+* [Exeter event](https://www.spaceappschallenge.org/2023/locations/exeter/)
+  * [Teams who took part](https://www.spaceappschallenge.org/2023/locations/exeter/?tab=teams)
 
-### Challenges related to space weather, and resources
+### Challenges related to space weather, resources, and teams
 
 1. [Develop the Oracle of DSCOVR](https://www.spaceappschallenge.org/2023/challenges/develop-the-oracle-of-dscovr/)
    1. 2 teams chose
       1. [BANSSAB](https://www.spaceappschallenge.org/2023/find-a-team/banssab/)
+         1. [Outputs](https://www.spaceappschallenge.org/2023/find-a-team/banssab/?tab=project)
       2. [Solar Storm](https://www.spaceappschallenge.org/2023/find-a-team/solar-storm/)
+         1. *No outputs*
 2. [Immersed in the Sounds of Space](https://www.spaceappschallenge.org/2023/challenges/immersed-in-the-sounds-of-space/)
    1. 1 team chose
       1. [Solar Sounds](https://www.spaceappschallenge.org/2023/find-a-team/solar-sounds/)
          1. Local event winners!
-         2. *Contained members of pre-event team [Solar Audible Experience](https://www.spaceappschallenge.org/2023/find-a-team/solar-sounds/)*
+         2. [Outputs](https://www.spaceappschallenge.org/2023/find-a-team/solar-sounds/?tab=project)
+         3. *Contained members of pre-event team [Solar Audible Experience](https://www.spaceappschallenge.org/2023/find-a-team/solar-sounds/)*
    2. Data: Solar Dynamics Observatory imagery in [`data/immersed_sounds_space/SDO/`](data/immersed_sounds_space/SDO/)
       1. Attribute as follows: ["Courtesy of NASA/SDO and the AIA, EVE, and HMI science teams."](https://sdo.gsfc.nasa.gov/data/rules.php)
       2. Data retrieval script: [`bin/download_sdo_data`](bin/download_sdo_data)
@@ -88,8 +92,8 @@ this easier.
 For a more in depth understanding of python, exploring these exellent tutorials is
 recommended:
 
-- Software Carpentry: <https://swcarpentry.github.io/python-novice-inflammation/index.html>
-- DataCamp: <https://www.datacamp.com/courses/intro-to-python-for-data-science>
+* Software Carpentry: <https://swcarpentry.github.io/python-novice-inflammation/index.html>
+* DataCamp: <https://www.datacamp.com/courses/intro-to-python-for-data-science>
 
 #### Python environment set up
 

--- a/bin/download_sdo_data
+++ b/bin/download_sdo_data
@@ -18,13 +18,20 @@ Usage: $0 START_DATE END_DATE CHANNEL RESOLUTION DOWNLOAD_PATH
 Download Solar Dynamics Observatory images to a local directory, for later sonification
 
 NOTE:
-* based on script from https://sdo.gsfc.nasa.gov/data/bestpractice.php
-  * converted from Mac/BSD date options to GNU date
-* naive, intended just for simple images
+* this script is based on script from https://sdo.gsfc.nasa.gov/data/bestpractice.php
+  * source script had no explicit licence
+  * changes made:
+    * converted from Mac/BSD date options to GNU date
+    * extended to allow retrievals based on synoptic solar rotation rate
+    * generally tightened up a little
+* this script is naive, intended just for retrieving simple images
   * use sunpy for:
     * more complex retrievals
     * to get .fits data better-suited for sophisticated sonification
   * see https://docs.sunpy.org/en/stable/tutorial/acquiring_data/jsoc.html
+* rules for use of imagery retrieved: https://sdo.gsfc.nasa.gov/data/rules.php
+  * TLDR: very permissive, but attribute as follows
+  * "Courtesy of NASA/SDO and the AIA, EVE, and HMI science teams."
 
 Positional parameters:
 * START_DATE: date to start downloading from, format YYYY/MM/DD
@@ -53,25 +60,32 @@ START_DATE=$1
 END_DATE=$2
 CHANNEL=$3
 RESOLUTION=$4
+# shellcheck disable=SC2086  # $5 unquoted to allow expansion of paths with ~/ or ~user/
+# * but as unquoted will break with paths with whitespace etc!
+# * more complex alternative to fix: https://stackoverflow.com/a/15859646
 DOWNLOAD_PATH=$(realpath $5)
 
-# Download cadence
+# Set cadence mode: controls time interval between downloaded images
+# * Currently available modes: ["solar" "daily"]
+# * TODO: expose as positional parameter / getopts option
 CADENCE_MODE="solar"
+
+# Calculate download cadence
 SECONDS_IN_DAY=$(( 24 * 60 * 60 ))
 if [ "$CADENCE_MODE" == "solar" ]; then
   # Use synodic (viewed from Earth) solar rotation rate at heliolatitude ~26N (/~26S!)
   # * https://www.star.bris.ac.uk/bjm/solar/solarrot.html
   # * https://en.wikipedia.org/wiki/Solar_rotation
   solar_rot_rate=27.25
-  # Perform multiplication with bc, truncating floating point component
+  # Multiply with bc; use scale to truncate decimal component -> get int result
   # * See https://linux.die.net/man/1/bc
   CADENCE_SECONDS=$(echo "scale=0;($solar_rot_rate * $SECONDS_IN_DAY) / 1" | bc)
   # Filter: only want 1 image from each solar rotation
   # Via .25 fraction, we'll cycle through 6 hour blocks: T00, T06, T12, T18
-  # Given channel+resolution images are usually available at ~15 min repeats
+  # Given channel+resolution images are *usually* available at ~15 min repeats
   # So unfiltered, would retrieve get ~4 images / H -> 24 images / block
   # Only want to retrieve 1 image per block
-  # So filter to minute 0N (minute 00 to 09) or 1N (minute 10 to 19) to get 1-2
+  # So filter to minute 0N (minute 00 to 09) or 1N (minute 10 to 19) to get ~0-3
   # images for the given block
   MMSS_FILTER="[0-1]???"
 elif [ "$CADENCE_MODE" == "daily" ]; then
@@ -143,7 +157,7 @@ do
     # Move the 1st downloaded image to $LOCAL_DIR, & any remaining to $ALTERNATIVES_DIR
     # * don't clobber pre-existing files (e.g. from earlier runs of script)
     # * so empty $STAGING_DIR after, in case --no-clobber means we've got leftovers here
-    # shellcheck disable=SC2224
+    # shellcheck disable=SC2224  # avoid false positive about mv missing a target
     mv --no-clobber --target-directory="$LOCAL_DIR" "$first_image"
     n_alternative_images="${#alternative_images[@]}"
     if (( n_alternative_images > 0 )); then

--- a/bin/download_sdo_data
+++ b/bin/download_sdo_data
@@ -1,0 +1,157 @@
+#! /usr/bin/env bash
+# Script to download Solar Dynamics Observatory images
+
+set -o errexit -o nounset -o pipefail
+
+error_msg() {
+  >&2 printf "[ERROR] %s\n" "$@"
+}
+
+info_msg() {
+  >&2 printf "[INFO] %s\n" "$@"
+}
+
+usage() {
+  >&2 cat << EOF
+Usage: $0 START_DATE END_DATE CHANNEL RESOLUTION DOWNLOAD_PATH
+
+Download Solar Dynamics Observatory images to a local directory, for later sonification
+
+NOTE:
+* based on script from https://sdo.gsfc.nasa.gov/data/bestpractice.php
+  * converted from Mac/BSD date options to GNU date
+* naive, intended just for simple images
+  * use sunpy for:
+    * more complex retrievals
+    * to get .fits data better-suited for sophisticated sonification
+  * see https://docs.sunpy.org/en/stable/tutorial/acquiring_data/jsoc.html
+
+Positional parameters:
+* START_DATE: date to start downloading from, format YYYY/MM/DD
+* END_DATE: date to start download until, format YYYY/MM/DD
+* CHANNEL: AIA channel to use
+           valid: 1700, 0304, 1600, 0171, 0193, 0211, 0335, 0094, 0131
+           invalid: 6173, 4500
+* RESOLUTION: image resolution to use
+              valid: 512, 1024, 2048, 4096
+* DOWNLOAD_PATH: where to download imagery to, e.g. /my/local/dir
+EOF
+}
+
+# Get positional parameters from command line
+n_positional_expected=5
+n_positional_actual="$#"
+positional_actual="$*"
+if [ "$n_positional_actual" != "$n_positional_expected" ]; then
+    error_msg "Expected $n_positional_expected positional parameters" \
+              "Got $n_positional_actual" \
+              "You called as: $0 $positional_actual"
+    usage
+    exit 1
+fi
+START_DATE=$1
+END_DATE=$2
+CHANNEL=$3
+RESOLUTION=$4
+DOWNLOAD_PATH=$(realpath $5)
+
+# Download cadence
+CADENCE_MODE="solar"
+SECONDS_IN_DAY=$(( 24 * 60 * 60 ))
+if [ "$CADENCE_MODE" == "solar" ]; then
+  # Use synodic (viewed from Earth) solar rotation rate at heliolatitude ~26N (/~26S!)
+  # * https://www.star.bris.ac.uk/bjm/solar/solarrot.html
+  # * https://en.wikipedia.org/wiki/Solar_rotation
+  solar_rot_rate=27.25
+  # Perform multiplication with bc, truncating floating point component
+  # * See https://linux.die.net/man/1/bc
+  CADENCE_SECONDS=$(echo "scale=0;($solar_rot_rate * $SECONDS_IN_DAY) / 1" | bc)
+  # Filter: only want 1 image from each solar rotation
+  # Via .25 fraction, we'll cycle through 6 hour blocks: T00, T06, T12, T18
+  # Given channel+resolution images are usually available at ~15 min repeats
+  # So unfiltered, would retrieve get ~4 images / H -> 24 images / block
+  # Only want to retrieve 1 image per block
+  # So filter to minute 0N (minute 00 to 09) or 1N (minute 10 to 19) to get 1-2
+  # images for the given block
+  MMSS_FILTER="[0-1]???"
+elif [ "$CADENCE_MODE" == "daily" ]; then
+  CADENCE_SECONDS="$SECONDS_IN_DAY"
+  # Filter: be greedy - get all images for the T00 block (T00 implicit in daily cadence)
+  MMSS_FILTER="????"
+else
+  error_msg "Unknown CADENCE_MODE: $CADENCE_MODE"
+  exit 1
+fi
+
+# SDO website URLs we'll retrieve images from
+SDO_URL="https://sdo.gsfc.nasa.gov"
+BROWSE_DIR="$SDO_URL/assets/img/browse"
+
+# Where we'll download to
+# * see below for purposes
+LOCAL_DIR=$DOWNLOAD_PATH
+STAGING_DIR="$LOCAL_DIR/staging"
+ALTERNATIVES_DIR="$LOCAL_DIR/alternatives"
+dirs=( "$LOCAL_DIR" "$STAGING_DIR" "$ALTERNATIVES_DIR" )
+for dir in "${dirs[@]}"; do
+  mkdir --parents "$dir"
+done
+
+# Get unix timestamp versions of our requested start & end dates
+START_SECONDS=$(date --utc --date="${START_DATE}" +"%s")
+END_SECONDS=$(date --utc --date="${END_DATE}" +"%s")
+
+info_msg \
+"$(date --utc): downloading SDO images:" \
+"* from $START_DATE to $END_DATE" \
+"* from AIA channel $CHANNEL at resolution $RESOLUTION" \
+"* to $LOCAL_DIR" \
+"(alternative images for each timestep are in $ALTERNATIVES_DIR)"
+
+# For each date, download matched images
+# * downloads to a staging directory $STAGING_DIR
+# * so clear $STAGING_DIR beforehand, in case rerunning script
+find "$STAGING_DIR" -type f -delete
+for (( now_secs=START_SECONDS; now_secs<=END_SECONDS; now_secs+=CADENCE_SECONDS ))
+do
+  NEXT_DATE_PATH=$(date --utc --date="@${now_secs}" +%Y/%m/%d)
+  NEXT_DATE_STRING=$(date --utc --date="@${now_secs}" +%Y%m%d_%H)
+  URL=${BROWSE_DIR}/${NEXT_DATE_PATH}
+
+  # Specify filename patterns (supports wildcards) to accept for download
+  ACCEPT="${NEXT_DATE_STRING}${MMSS_FILTER}_${RESOLUTION}_${CHANNEL}.jpg"
+  info_msg "Downloading images from $URL matching $ACCEPT"
+
+  # Download any matches to staging directory
+  wget --quiet \
+  --directory-prefix="$STAGING_DIR" --no-directories --level=1 --recursive --no-parent \
+  --no-check-certificate --execute robots=off --reject "index.html*" --accept "$ACCEPT" \
+  "$URL"
+
+  # Identify any downloaded images in $STAGING_DIR, and process any present
+  # * uses crazy read approach to count files: https://stackoverflow.com/a/23357277
+  downloaded_images=()
+  while IFS="" read -r -d $'\0'; do
+    downloaded_images+=("$REPLY")
+  done < <(find "$STAGING_DIR" -type f -print0)
+  n_downloaded="${#downloaded_images[@]}"
+  if (( "$n_downloaded" > 0 )); then
+    # Identify 1st downloaded image, and any remaining alternatives
+    first_image="${downloaded_images[0]}"
+    alternative_images=( "${downloaded_images[@]:1}" )
+
+    # Move the 1st downloaded image to $LOCAL_DIR, & any remaining to $ALTERNATIVES_DIR
+    # * don't clobber pre-existing files (e.g. from earlier runs of script)
+    # * so empty $STAGING_DIR after, in case --no-clobber means we've got leftovers here
+    # shellcheck disable=SC2224
+    mv --no-clobber --target-directory="$LOCAL_DIR" "$first_image"
+    n_alternative_images="${#alternative_images[@]}"
+    if (( n_alternative_images > 0 )); then
+      mv --no-clobber --target-directory="$ALTERNATIVES_DIR" "${alternative_images[@]}"
+    fi
+    find "$STAGING_DIR" -type f -delete
+  fi
+
+done
+
+info_msg "" "$(date --utc): download complete"

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_100646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_100646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8823a7336cecef78372801886c41ceb7c46a184809163ee2b3d66657bcabe3fb
+size 61073

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_101722_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_101722_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0088e81dbb2bb74bc99805cff75fef2918da46a40d253f57328a909447404967
+size 61181

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_102722_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_102722_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be57fc46f3a20d85c2c8238435b9f95424381688536391c35f5e418b2d9498c4
+size 61180

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_103634_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_103634_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce2805914951148a05b3a2911889a3163a9848b5289d9cd29b98ddfb430d4b70
+size 61130

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_104710_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_104710_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f111dba0b4f37b4b91c0e6b9ecc1b742c43f89cd758f7d2b9e0f11a7e5a38a5
+size 61091

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_105634_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_105634_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17e549334b9d7e8b8be65d28cb6ddd8b4391f8dfff0134c1bca297bd61ab2c1a
+size 61125

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_110546_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_110546_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:65bd8bb5d695ba33b84963fa05ea361fd3ca650c4de718cabe29f23e4ef58bac
+size 61089

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_111622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_111622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:059a2ea99f01526becdc9ca83290a1df9aef725babd8045cfbcf9608233d1f8a
+size 61202

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_112646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_112646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a95c970bd2ce928bd262287f1a939bff0ea9a54941e3d5e162e6d077881df52
+size 61124

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_113646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_113646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee537b0b241f7d0a2d6fee09c98cfefc317c2d53e65edb2357415979bfd7208f
+size 61293

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_114622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_114622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44709c417e93d740389356b5d824aba44dfbda2cfba1c5bbba634cc422d9b1ae
+size 61284

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_115710_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_115710_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7f3bc05a440246a5a6a32b2d41b09c03ce34a7b478805984ebd31299b113d105
+size 61165

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_120710_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_120710_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c46f09549728bd35e5eeb1c83f57284c6b6719c7f6b1f58780e59ea7647f609
+size 61153

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_121658_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_121658_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ec5ff3e81276565c28027c128ac0a83e726c289fdd6d940d922ddac103e5ff0
+size 60982

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_122622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_122622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b7c14c1c4e1b783833fa2539b59c8b9fbcbcc0107a91c793fe3e6f0d1c2fd9f
+size 61038

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_123710_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_123710_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bd715bc1eba643149a45a27980f124f66036faf50d5ea2dcd6ff27f334970ff
+size 61042

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_124622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_124622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dedf54b10e9d5f4e5ba84f05a8f6478e847242e54e2e9b9e50d446b4c301ed3
+size 61380

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_125710_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_125710_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa82468680991ba542d7c291799f214a9d8f340262078be9132e26165a151493
+size 61559

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_130546_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_130546_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f047a244b6a1c127cd9be0128954672a32be22d7215350828f8c47e430d97d7b
+size 61420

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_131634_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_131634_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ef35de7cf5046dca726610967554c5f9151bdf71e80e946b10c8f546c8f4a89
+size 61367

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_132610_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_132610_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7496a7dc11d15ca2346861afccbdd48061578614928ba87b23bad195ad182f7d
+size 61320

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_133646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_133646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a615a3a46cf56f86be1c0928c7818a34bd9e25fc06080bfee95ae4662924ab69
+size 61339

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_134646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_134646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ce6ec6a8192ecf5f71f0dc062948b569509bb7b2cb22a254994117c6791f8fa
+size 61285

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_135658_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_135658_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:987cf2616d7f1eee2380705fbe15efddd8202b14e45ad6a447a74a8cb77e819e
+size 61333

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_140646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_140646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59a7848fe9d597c607f189ad4e736ddfc5c1ddb5c6a263306fd10912701577b9
+size 61361

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_141646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_141646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0aba5261917d7b26cdf52c1bccb6d3e79d57e719ceac7fcd6a442bb1a5c82522
+size 61362

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_142622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_142622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:898e93fda279700e188ab4e7b29e9bd3d6432823ca9daf17ff6574f811ed751f
+size 61467

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_143658_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_143658_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c58458177581de72f5ceedd057a5ef07a5691b355c00a61503220605044b126
+size 61305

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_144658_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_144658_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b40dbbda8d3acd410ad4169dc2bfc7be951735328542cf95ef156f1658eb37b8
+size 61154

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_145622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_145622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee960334b6a21c8af1410cad9711406df3c0834b8933e57f347cb309618e0a1a
+size 61115

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_150610_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_150610_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d010ece2dbec42d4f73b6aa7ee191ca09d6a529c2f9cfc6daf3331e55aa136d7
+size 61117

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_151658_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_151658_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a269b41c39ab9f6e6ee813e4b95c2711b1f1f6b1f38371b0c3c959d4ac49acf
+size 61130

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_152646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_152646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42c9927e0f2ae86d0b89fc3bd144b8a8812964ad5f62b69b08c0f3c26ee6248b
+size 61144

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_153622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_153622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:792f15ee1e946a57a754a153a0ef6bfebaf57bf29c7328a9271faad0bc0f2bdf
+size 61156

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_154658_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_154658_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:77f93d3c2734b18d3b6f05f58933d2f6c1a30107e6db8d31133fa1b651004efc
+size 61160

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_155622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_155622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9424fa99efbe9ef5db85810be67b4c78570370a87b2bb6a073019d45ee2d7c50
+size 61073

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_160722_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_160722_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46e7c4d08a557ac384714a15c38d4fbeedf7cf79ae520c95f5226c39edc185d0
+size 61190

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_161610_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_161610_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56bc04f731abea5ba202021706ed2faabd445b51883284fd0cb4c382586a0c40
+size 61145

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_162622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_162622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb9bbdad0980e90fab362c30e397a76d30b94e638eae1dd10c1123cd5e2e8c85
+size 61128

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_163558_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_163558_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f943f6bf697dd005d6bce29c32484bcfa244f3089be238b7f47db4a1c58863d6
+size 61276

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_164710_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_164710_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83e0565ca24b2234ef3f0facc6f4914dc123f60897713519cd08fba3d1a2101c
+size 61171

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_165622_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_165622_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e52ed998adcb98faa2ec27b96646910074497c7038e4c1b7696b87aa2a6baf87
+size 61347

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_170634_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_170634_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e81aaefa7680a8afa23dc7e8d05e570e20633944d9c82d463883e48460fa6084
+size 61238

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_171810_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_171810_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c44abb6835076e88cc9682307e15420add6e00f1532a219b984acc93ddc993e7
+size 61168

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_172646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_172646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c54e188c2cd2ed0964024fc6977c028dbbf6f6bb37f13a51306e535174ff8aa8
+size 60906

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_173710_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_173710_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c3a0933f107f599aa7c59aae67768ad806bd37239120474978619ae256acf95f
+size 61071

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_174658_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_174658_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c66ca90d67df8de1eed5bf7159202a736b94974edf453d249400dedc784c0e65
+size 61135

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_175658_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_175658_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf6b714486620cc409912e9981eeb6671f77edbe887fb6b25da6a6bc1a03fdd0
+size 61178

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_180646_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_180646_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:80b55e555cba2fb7ded51cc1d9049a45c31cf621a8879f2376f387542b8dcafc
+size 61116

--- a/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_181634_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/eruption_time_sequence/20231002_181634_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61db68762c46b67f9755079933d9f206b79dd34a9764edd6dee43b2e99edcbda
+size 60901

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100601_000156_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100601_000156_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb16835cdec4a6c55963eced43427c2d23223078c1401e99b379936ff0d2a0f9
+size 49406

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100628_061508_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100628_061508_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e81b08fc9b60c46e5af2ec5cf1b329d00e0f4f923c6f2ad51952725eb6a6210f
+size 45658

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100725_120256_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100725_120256_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc6625ef214affe74d99d927f0c7e589851f6c4576f1b91724fb417acc17e624
+size 44838

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100821_180032_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100821_180032_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cca051a905b1c64e2fee95fe1510af4b8b6c4badd0966dcbe38aafb9e30dea17
+size 48846

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100918_000720_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20100918_000720_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17941a0915a82b340f87590a5e77cbdeebf75f890bc649f82c8e724f305ae83f
+size 48448

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110105_001932_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110105_001932_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52d6ef2e9ac267773217cad8906994634d314951bfe752e13282d8cbc438e464
+size 50006

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110201_061932_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110201_061932_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:496b22502327cc846ed1bb5dada8db367d59964fc22e54a1c193771de24d898a
+size 51465

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110327_181456_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110327_181456_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:419b6e70831d7036ecc131eb9a9b0e6e18a528962d76a61fbeb28aa5a5fe91aa
+size 48717

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110424_001132_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110424_001132_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4f97c3c441e6396b74078edbf9367245a12527bd07eb1ebee5205ab18014c1f5
+size 48410

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110521_061020_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110521_061020_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:881bf987771636c0e4f75cb496da6bddd7cbaef09e4873fa1ea043257c13f597
+size 47307

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110617_120256_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110617_120256_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:143cd56d6f838a86b8830471227a9dd9e59bfecefef532856f34ba13ff21299b
+size 47583

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110714_181456_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110714_181456_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c268ceddeb3d8a6b41017b3152a417207bf09f85ed217b5816dee1e91ab7a8bd
+size 48613

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110811_001232_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20110811_001232_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21a35eaa88a268e0770d0c08aa1c381e2746d92620f7af20e207f3428e521d70
+size 48395

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20111004_121120_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20111004_121120_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9e2bb75b9bc8849986453da8b4ab26c5cc18fb9992cf3353da2b16c42d4a9f0
+size 50732

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20111031_181144_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20111031_181144_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36a3abc955d5f3f03284aa9a202d31f1da754f8fc56b88cf1ae59aa10c055ecc
+size 51787

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20111128_001044_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20111128_001044_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da3bcf44a249369bac546eb9b5f567dd4dd74fe1674d06b7e19c34fbe506a82d
+size 53010

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20111225_061344_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20111225_061344_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:41393527e3f679da877ca53525a29a28c7220fe64f627fd1acbca1558eeef127
+size 53500

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120121_121156_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120121_121156_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df0695f706f51cd14330316f6a8d9ca3cbcdf52ad4870aa441ab90ce87cd49b6
+size 51942

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120217_181332_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120217_181332_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b06ced154f9387685fa3987343baf933e19c649a48cb6d7c9b2c2d5230bac669
+size 50469

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120412_060420_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120412_060420_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0c139cfb29a933e8454714a9f3cfb871b61d5a281fa03489de48b787490cce0
+size 46089

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120509_120056_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120509_120056_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0dafcc359d458e8630a2fb02f8ca8b4ff908703800cdcb02e3c6bb39a8f742b3
+size 46693

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120605_180033_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120605_180033_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d58970a81817cf4741d08e188d8f8d922fcc6900b5cbb7e82d211e0e21db9bac
+size 47256

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120703_000009_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120703_000009_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de89934c64e319b742c93b14df6e986499abb0be2589ad4cb012d28dc36fb4a7
+size 51071

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120730_060007_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120730_060007_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:557755e374aeacb4f3c352fc867eb2d734b635f282977e93322531fc75a9c78b
+size 45987

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120826_121443_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120826_121443_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8eb6f920ae7d6016d2b2e5c56584b34e083dbaa4f3d5f8d47cef7084002d4a6
+size 46184

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120922_180031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20120922_180031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c506c96462d32ae5d5cc1ca61dbef2cf9ca0ebf23e88525bee600e831cd5da0d
+size 46327

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20121020_000031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20121020_000031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f75e1c3f00188c94d6723a6ef6096bc85bdae2b5800c0215fff1994a35b1cf2
+size 47217

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20121116_060107_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20121116_060107_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ec05181013451524d01003ef4c8a51b6e00f5e5116fea2bbeafbc9c85ca9b60
+size 47851

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20121213_120031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20121213_120031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f53cb08cf0ede5dbf16716104c34ab1d7a9048d3bf46688e8946086ca673f90a
+size 48012

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130109_180019_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130109_180019_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:804fee2e0336c1a3cd99f789a5431f5c91bdb0243c475a99a0de0133e162877a
+size 48639

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130206_000107_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130206_000107_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f71367b2e969b42c6e794f88db82176af29b4c7eb9981e21f210679f76ec3e5b
+size 48346

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130305_060055_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130305_060055_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56e3e7f9d5df3b7174430821ab47b891eaabbb8d9ee8a0121dc44b40faf5c4d1
+size 48364

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130401_120031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130401_120031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d29efa5574be5208af16d1de344ef58ad7a6d13a2ac4c3cdafa2afb94e1d249b
+size 46294

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130428_180055_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130428_180055_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ccf6aca9dbb740fdc7da90927bfae8178111f759ff9c4bb7b788f77124d7a959
+size 46490

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130526_000055_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130526_000055_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed02bc62bac4f038943ebcf2b5c7a0f38d694dc424a93936cce6dc5fa4c203ae
+size 47974

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130622_060043_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130622_060043_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3edcd0370bc7866bcd796cb1a5bad7b2321c74e5d657acea255e933e658098ee
+size 48325

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130719_120007_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130719_120007_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5257ff6c1f57a40ce0e3389a18f7863ed10302d0352837886dd3e1071b9cd620
+size 47673

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130815_180043_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130815_180043_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:209d3607393acddd97ffb51a5d9c28e7c959cd489567b6d7f42304076fceab6d
+size 47733

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130912_001419_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20130912_001419_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bbd3310d64b503b7225cccc8691646b4efd23c1c6aae90685b95f7e17712126f
+size 46081

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20131009_061443_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20131009_061443_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a8f71fef6316b7e3fa5989204b66995559be39651487dc9a0836634d0822d4d
+size 47665

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20131105_121455_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20131105_121455_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7c0b0c4de41e04a98f3e8aa698e41297f925a58258c40e245e33a01186eef3f
+size 47042

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20131202_181419_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20131202_181419_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02186971546041911160dca205eb891f75e3d1e270b2511b05bd3d7868235125
+size 46749

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20131230_000007_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20131230_000007_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eea1854d2a1cdbbda8a5247e1fa49421d27503ec4d38a01365fcd18bb7584949
+size 47007

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140126_061343_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140126_061343_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4173c8eaadfd5f702eeea064d2099da5874f33bdf31c7b98e91fb9fe5816b64a
+size 46768

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140222_120019_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140222_120019_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7566e7dfb7553b8d677114930b734fc6279c33a5286ddb1b3ffeae419757cd3b
+size 46214

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140321_180931_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140321_180931_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:702ee41127bf42cf28e49d2f4fa5e170216543ba3507f1bc13590aebf7061b9c
+size 47768

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140418_001007_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140418_001007_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3ea7299f84b320c1498afd75275654e0a662e35b7058dba41b12ae26fc9cae72
+size 47566

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140515_061019_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140515_061019_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:702a5a1496b16086660d7772927b0ed19e5070c275d994fb27a891bcc5d3fb91
+size 46955

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140611_120943_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140611_120943_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4787102948a96ff7e35b62a5bf8de9fe9e8236b9d43ac7e39e8302f1301eb96e
+size 47216

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140708_181007_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140708_181007_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ef46d021ce581c4785b84b29a0eb8bb83f799e17ff83b2503cd283a111b2035
+size 47846

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140805_001031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140805_001031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a195ae6013d636268d7201caa69a02418d2034b22dcb495643e19ba188f71918
+size 47817

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140901_061055_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140901_061055_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a18beee360c9f61c80ce58f8fcb9c51a76d973c7bcbfec53030e9bf594d504ab
+size 47985

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140928_121031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20140928_121031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16025ae7660b379993256b8c5013a08395b8fdb255b9cbd28604a1c4f18dc449
+size 48877

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20141025_181009_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20141025_181009_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:051d6b84fca1f6c07269f5c8da08a063059e40d2db21833d759b9e791190f0b5
+size 51545

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20141122_001031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20141122_001031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0bee8a8007a01957eeffa35d8452c6463a51eef83976a65c898f9e2a6c958f14
+size 48946

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20141219_061056_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20141219_061056_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e3986efaea826fdf490851bc09b8ed4767e7b4e12c2e54680248ea0870c4bbf
+size 50431

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150115_121019_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150115_121019_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9d671f6a3cc3237c63171d7ddb5b7d721d10beafc59df75f33d84b37ef5a4c66
+size 48598

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150211_181031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150211_181031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb11e5c7ae3ff731d9fe799dfcf42c7aca3a030a3f221ce6fd55e11b007b2661
+size 48935

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150311_001056_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150311_001056_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a83747187719105622058cff8a974c8744b3d91047b92d559e146cf5f944d66
+size 49018

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150407_061019_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150407_061019_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f9e8ae8ae7720cf8d32ad1e71d7af284a622bb1329c7102fdb54935614924dd
+size 46605

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150504_121031_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150504_121031_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5b5c867606ba9859735726402bcfedc4c52c55ed785dcd796d088d1595a7d5c7
+size 45830

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150531_181043_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150531_181043_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c2e067ffe8588dbdacf568bf986a7d0144f055e4aba254572bc17601be42957
+size 44557

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150628_000931_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150628_000931_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b338c19abda474e27571b73d1bc3554d159dbbc31318590f494d4170eb293a97
+size 44100

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150725_061054_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150725_061054_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:33f9875071051e4c77a1db1bfa0dcd9d1010e780c9a5bdfe9c4a0dce0bb2744c
+size 45056

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150821_121030_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150821_121030_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d488643be70b780b90038834541f27427c5765c0dbdd4d5f35b5e429b8474163
+size 45088

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150917_181006_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20150917_181006_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2278e3e1fe4ed1ef4a5ec33c562f8eb9eed73c124e32d735e1b7e621c737c431
+size 45639

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20151015_001030_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20151015_001030_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:30319b48e4d67eba34ed35cacac9fdd8cc7d71cc11a6e515dbc7fcacdb17e988
+size 47472

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20151111_061006_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20151111_061006_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c9ddd412b14952b06cb7c5b93930da45127bfe6e49f0c4eb8a6a28075ead9df1
+size 46963

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20151208_121054_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20151208_121054_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36019c0bbb08cf18be450f4c7064d5e29a47ef5af12a655a84458712d9018a42
+size 47634

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160104_180954_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160104_180954_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2dd539108746ee943d018b56b17070a16556404ec04bcab8e32d69e1fe4b938d
+size 47755

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160201_001042_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160201_001042_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a41cd1f6d5cb227120e1e60d65736b1bf55ff8cc5ab1a7af55687134b9403f2
+size 46298

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160228_061130_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160228_061130_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3b35eb810a5cd2fb96617a814e6bb115fd9f527b991b29b2a88c80324b3ef43c
+size 46217

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160326_121006_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160326_121006_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f9ef476097269539218447d7d2326a1905905707eb74ec800414528b37798fbf
+size 45445

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160422_181030_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160422_181030_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c288ea31f6105e88522693ceb5a8772b791e767c499fe6fb2c0f210fd7853df4
+size 44246

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160520_001030_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160520_001030_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3a5eeca48c4bac0dbc6fd6fcd8251c8ce2b725d6059017a2adcdc4ab24843799
+size 45255

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160616_061018_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160616_061018_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eb9d6317daa92fa5a6ad6567b1d82b4e49e625c7d7689d540deedd7b6338471
+size 44717

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160713_121054_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160713_121054_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d1ba08052d09b49386f2702bed7c4ae8ffcc8d9cf5abbddc83610ae514dd51e
+size 44497

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160906_001030_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20160906_001030_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9b462d55b1216e50041ec4d59bc2cb225a2004b049392f25117a8a6b92eaba8
+size 46536

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20161003_061054_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20161003_061054_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5ce616c0a636cea08e4467974feb12bb5dba90a48e52e725a8e0952a0e68cb7a
+size 46081

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20161030_121042_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20161030_121042_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:622cddafa33ecc30fc6f4c3dbefbdd72a9dce59406fd7941715e1be85369e4a5
+size 46731

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20161126_181030_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20161126_181030_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:235b63d88f269a4ddae74972548c11177f4381626c3c08d36aec28bd3d1bbc05
+size 45681

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20161224_001130_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20161224_001130_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e00b2920f604cb6c5725800f1df2121abb675ceeb5fe7810102d0c8ffd686932
+size 45076

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170120_061153_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170120_061153_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:010e656913a595b9514d6d8045ce2efb356f0c099d4ccb18d9671acc2cc91240
+size 43148

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170216_120953_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170216_120953_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1c4a434de3590e4f1eda9724d0b391247359f1fe1c449cd1d85364ff6a83ff0
+size 43999

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170315_181129_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170315_181129_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88d64b72c74b930fc658450ee1ad6eb568162af7043fc189a8d6748e430125b3
+size 42223

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170412_001029_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170412_001029_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5612d20f2d8f4eca8806f76f69d86b86df4a33e2c5dac880c21a52756f753996
+size 42191

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170509_061017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170509_061017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aa64efdedb3375479499a5b104e630c8eaf979fbe426c833eb1044a5aee122a
+size 42461

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170605_121041_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170605_121041_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5047ab9cdd760135e7d0867882fc1130503fc03314226e2994f9b7d003e8b333
+size 41686

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170702_181029_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170702_181029_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9c1a37544d75ac2ee6500d34e607015265994cf2b32177d7560b28baa0807e68
+size 42907

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170730_001105_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170730_001105_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:694d395f5b27f1dfbfc16e7725f0fed5711c8bebf13d29262b4305f14bd58ee3
+size 44968

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170826_061105_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170826_061105_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ea56914155fe6cbdba3f480d23e635086d033bb9d55b379fcfe0bff1787317ef
+size 43774

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170922_121041_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20170922_121041_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67a70ca94b521c7d6e879dc1a2e8c82ef2ed032ae5e3b7fb7f9d3d0626be7051
+size 44478

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20171019_181117_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20171019_181117_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:39a9650366a0a77f91cc01a148d9d9bafd54e11d46365f3567f9b7d4ee18e4d5
+size 45050

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20171116_001041_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20171116_001041_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:416774b2f95a68cbe3cc6193eafa996452cc8ea40749945b64a6b66037488c77
+size 44279

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20171213_061105_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20171213_061105_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61fb0740b368ee27323ecff9db6068a7f5d48adb4f52d96ef439a80ebbefb0b8
+size 45282

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180109_121041_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180109_121041_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b02c37e10ebd65e2f0bdd1193e9f77b5c599ebc1136326cd83910552ae995463
+size 44291

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180205_181005_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180205_181005_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ce1f51df1d2cebf4a0c18205fb840ff855135eb9f7fe38d5116e8212e805b96
+size 45080

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180305_001105_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180305_001105_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caa24aa23ff99ccd73e7841dc86bb33cc315e4a086158c388a44be98ab7a3539
+size 46594

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180401_061017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180401_061017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7ad4d9b9e82537045ec410c00a3128f4ecd3287ebc37c8c5ab1e83562bce030
+size 45434

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180428_120917_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180428_120917_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b8762cd5f0d66b0f61fd0198607f2b5e289af0ee3e8c26fff17ce8c10ccabdd
+size 45052

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180525_181053_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180525_181053_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:115e53ca0c9edc32ffbc71534c43a318b8da365f98cff5b1b66aa896c2120c55
+size 44067

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180622_001041_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180622_001041_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9066a487333de80af3b622358373a6c9249e9e82eb1697bdbeb215b2002b8ec
+size 44760

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180719_061005_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180719_061005_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b81eb6765ae640b43529c9855ee6c37b698039bd775229b62e45830f6b8a7368
+size 43243

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180815_121029_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180815_121029_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f64ae39a42bd80b8ada1dc0e6852fe7862080fcfb45bc132ff8df980d8cbb71f
+size 44556

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180911_180953_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20180911_180953_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:939457d243ebbf608ccd4a855994865d0d23cfb11575ec7885c05c9076709fd6
+size 44752

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20181009_001017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20181009_001017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc3f182d7393bd06d1bc34280e048742a128b8543d4eadc359a3fd39c22628e5
+size 46004

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20181105_061017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20181105_061017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9cea20e062f89beb6d0a623d129ff8a64211058c899a83c09002a85927c5993a
+size 47168

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20181202_121017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20181202_121017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a583bb1898d19ff25ac9dcbe6fd42ca173b73fa47a1a9282274939ae7ec5825
+size 46797

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20181229_181105_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20181229_181105_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4de62b7db9e03247df921b300c39957c94264d85cc99e50d1563c114e0634155
+size 45694

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190126_001153_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190126_001153_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f979ea8479c843684f91f4d7dca64ec74e8e8116ce3bbd33f87be61be18464e
+size 44867

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190222_061029_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190222_061029_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35c96a772bc2cff8d007c8eac476e92c9e3c1edd682b554abb8368d9677dca0a
+size 43913

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190321_121017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190321_121017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5dd0a453e79d08621498fb284f6935c9a64ec3758d9f9f2eb608a79ba5d5c062
+size 44288

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190417_181017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190417_181017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee6745e12b1f9faa4afe1d8ea82e75da31ba0ba3b727dc36e61570dbe1d36663
+size 43545

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190515_001029_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190515_001029_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:abdfffbbb7918cdca3a902cf6a066fff73513362c992f1778184ad0f093284ac
+size 43760

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190611_061129_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190611_061129_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c2bebc0570cbe93ecde3677a6da13d06695fed6cd78430261040d2df225ec4b5
+size 44164

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190708_121041_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190708_121041_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:843aaca9e1af59f3d021ed972f91d4a0e83e96e6b870cf77e6d71abcc5111d93
+size 43613

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190804_181129_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190804_181129_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a057f1d1dbd8b4b74e1ea98a00b3b955b3ed51a4e1b531f70122ae59cbe08e68
+size 44515

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190901_000017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190901_000017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed011e6bafa43d884d803b822f9defd4bc80217a0fb3d5c608f60d63433785ac
+size 45568

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190928_060017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20190928_060017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:98fe3bb312eee04dce45cbde7be7cf4eb36ca678dfca77073887708468831f49
+size 46031

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20191025_121141_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20191025_121141_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b2a9136a6ea74eab488bdbd7b531edb80ec5af39739a616542db1bdd3fe27f8f
+size 47035

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20191121_181005_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20191121_181005_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8ed131bd727a2ca9875fbb5afabe572af2aef4887c0ee5ee6b9c0eb2e12d640f
+size 45629

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20191219_001053_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20191219_001053_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bb7c116c7e436121c2fc744ce75fb17b4913abbd17bae201d2302bc43998f133
+size 45974

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200115_061029_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200115_061029_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1d92ee84c107f977cf9bad766f5dc1040879d08190484099a4aab895a97b5701
+size 45221

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200211_121041_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200211_121041_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6f11f1b8dd5816f5cb43e9b5300ce24d60a2eaba3f4721728ad2fe105fe0a635
+size 45936

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200309_181105_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200309_181105_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:25c61379cfff86535688fe16b2f2e517387709dd14bb3068d5054a132bb19972
+size 45307

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200406_001053_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200406_001053_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9971d4e7f1b0a0a13d5d53598f8b4bafde170ec889f2c0e351cd521a1bf7b1fb
+size 45187

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200503_061053_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200503_061053_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f976ebc44bf192ad97524c7304a6d65c67aae0708e893d78820d06f9fbd0c1f5
+size 44672

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200530_120741_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200530_120741_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57b3d4b9e52372cab1cdef5c48b87b0d1ac5b760853f798f8837700f87f4d963
+size 44729

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200626_180841_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200626_180841_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae378067a7541e68e3bf8a3cf8ca07c85dc1367c97cfd9dd884e2bd6583ad4a7
+size 44438

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200724_000705_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200724_000705_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97eb094defee1d4770709155df9ae5ab5a18d3d5cd2adddb38dc19c9732f662e
+size 44691

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200820_060705_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200820_060705_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:83bcf0f3bb95c8095d4e680802443e90f1925651127db08fdf303c55d9875f5a
+size 44323

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200916_120753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20200916_120753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c5691b98fc8a8e979c32d8aae0d9d945cdf8cf04ae7c31201afd73e69bb94348
+size 43859

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20201013_180717_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20201013_180717_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:652eb312611dc61f1c9fb274d12d6b83e647fc804065cd975997a457e632a601
+size 44819

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20201110_000741_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20201110_000741_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcd4a2706a61bb9469b1ee266eb46116f97de6e49282750c4d076f17c5b3ddc5
+size 43312

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20201207_060753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20201207_060753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:13dd7d55d176fafd8a0705938e97d106fe598e06d0d4e6eca76b6b3d1377e3bd
+size 44466

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210103_120017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210103_120017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1bd5d8fead7eb02466b57cb2c5f602ae0ad6918707d998929116cad363e3535
+size 43649

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210130_180017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210130_180017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b264bf61272f291174996fd0386c74c761db3478895b7f83e663535a7d211d64
+size 44291

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210227_000017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210227_000017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e10f9e042d8b6a4332d29fbb0a229e59ad14ed0bbaf2c815b27187af01f4f73
+size 44162

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210326_060017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210326_060017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:38abfa819eb2ded6468c111239a949b20578a6b01dd427a9f8fc76ba493b7082
+size 42964

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210422_120017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210422_120017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:106c527261d822cdbb7271843ed0d2763cf6650726c58690df0508f06f6b780f
+size 43779

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210519_180753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210519_180753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa73eabee9860e7487d3ae9efe890f8ae4cabab5126b6b4fd3dfa9ad51788068
+size 44645

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210616_000017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210616_000017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7d6c9fbad62f69720759606345d3c11693eb771bf8f011ce22b278693ef91d0
+size 44170

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210713_060017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210713_060017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e35f744cff4c8627532c0aa3ce232cd0dd4c652e237b0187c6897057a31081d1
+size 44537

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210809_120729_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210809_120729_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:720d208e64318f56223996f3153988a3377927f497d84ff61bbd7cd75dcfa971
+size 44280

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210905_180705_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20210905_180705_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:23e672bcc63371f3db2a668475d180eb9b24cc8329691b3d53e0e5bdd5fc3c5d
+size 44933

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20211003_000717_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20211003_000717_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:eb97072bab4a782b5e06e52aa7a63a74bbf28341636452a9022037eb5975128b
+size 44517

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20211030_060753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20211030_060753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aff0c6b4cbd7d9def94a8b8ad5e60d2b8eb8a08611b8761db0ebbb9e7ccba90f
+size 43984

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20211126_120717_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20211126_120717_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bf9b3545d14ed2627ed8e801c42f77597129d0ad0987a506a356511d7ad748bb
+size 44687

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20211223_180653_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20211223_180653_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f7413c42171e26af00b44e93d73f6a2edfdcd85a383037ed026f367a5297566e
+size 46036

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220120_000741_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220120_000741_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d047172ea3a3a9a9361064c466040d7e28732277e269b62758312393015f900
+size 45779

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220216_060705_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220216_060705_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bd15a4823366e46600001d71c652d7f554506347c4e5a08fc64d30a6dbd6814c
+size 46805

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220315_120753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220315_120753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b119f91fc020fd5764e6e541fcca85734ee9b054aff5f3d4719964b482a9da6
+size 45134

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220411_180729_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220411_180729_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bfc48fb39a20482be91947785a98b008e59c7773d51cd753f0e99dd142d62a21
+size 45431

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220509_000753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220509_000753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:866b9923cdf313d3bdf00fc6e77f1c4eaf32c6d868e97b51c7ec746ab9dfcca5
+size 43718

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220605_060717_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220605_060717_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a2df6f0718b4b0cee0faab4e27a49e1686625988acfd84a94e0c27888e621100
+size 42991

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220702_120753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220702_120753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54944c6827817f37e06589d23129ddcf482a0f6df9a9a783a90220bf01e43451
+size 44107

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220729_180017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220729_180017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c8600854128f0f0b6764b6363ea120d3e45aa8545657dfd48816ec7ead8a85d
+size 44428

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220826_000017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220826_000017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:17424742fbe5834cb4acce28380056fefa624e2c6ad63f02b38a7bd26d8bc67a
+size 45148

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220922_060753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20220922_060753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1449abe67a57bfa8f7b91d9cad616dde34dfe2d395ffcf8b59e9f42543cda95c
+size 46873

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20221019_120805_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20221019_120805_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2afd9697297c348e0014235936f2dff8e74fe3f890b7e3ffd0e6cb6416b22b88
+size 46727

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20221115_180017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20221115_180017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e1dfd643431dfd0bbaae049764cf697c78b598436cefee19092634306dcb1e2
+size 46503

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20221213_000753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20221213_000753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0f74db189dbc00bc7e26435f12211d1cd8eff2afe17b092fec0e91569ff1d7e
+size 48175

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230109_060741_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230109_060741_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f4e7ecd445e4cf4dbbfad1b62f2f7c723699209cf76af0cc5e08bcb744a24d64
+size 46687

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230205_120017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230205_120017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b64b8aac64d19a0cdd8698fecba48138ce41167874070f5b6f65ae2213e4fc38
+size 46834

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230304_180017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230304_180017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df67d0f41c1d0760721f907a29a1da3f1232810b51dc4cf22c9dd9e12cd962ac
+size 49981

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230401_000829_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230401_000829_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8e1d2896d38ab0ff68b334432fa7161e8c7ee8b03f2ce2e37c48a80593d4a267
+size 48145

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230428_060705_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230428_060705_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6aecfdb4da3de917d89a044fc8b2eee880c0de4fd9adf0caab1b8d7675ab1baa
+size 48208

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230525_120741_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230525_120741_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9bc9210043ea39ceecce6f47edddeef4f732501ca437277ddafe774056629ea6
+size 46958

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230621_180753_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230621_180753_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2384b0ec22dadc312bc34431946ba1f16d1f5646d82024997db11a72006052e7
+size 46250

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230719_000841_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230719_000841_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54db4f1923e24147ecc40d38ccce4ea5002f04cd08cb6d25e0c4b8ace43d7d70
+size 47766

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230815_060729_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230815_060729_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91f7aaab66bf49723d1df2f909512a04dec829d647ccbc98811c999d230ad904
+size 48067

--- a/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230911_120017_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/solar_cycle_sequence/20230911_120017_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d7d7f1d4161a4b726bb925a1dd636aaae9339405cce28700c002fb97ffeef0f
+size 49814

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000615_512_1600.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000615_512_1600.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a95d16757b219dc3d0c93bcd2e2bb27a8522f9fdcf698bc12705445abef74a3
+size 51019

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000629_512_0193.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000629_512_0193.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f3d6446649b9cf17b80a4126c64f69c692d25ac2514dc08c53a7d859f82fcb93
+size 49281

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000629_512_1700.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000629_512_1700.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a35f498dbe2b6764cbe670d401fa2acd67e12031e81e80799941b7c2d37aabb
+size 48559

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000630_512_0304.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000630_512_0304.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a9182906cceb8715288daffd55a05021fa49556f3403c8230330c907356dbd3f
+size 65856

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000632_512_0131.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000632_512_0131.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:18619e247b051d5f5a04c9b410743673c79b0a988d7438a644662162a5646b80
+size 61685

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000634_512_0171.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000634_512_0171.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:227707e932c296ffa734e947988a68d0d1c25a745fea5d3ac00db078c5916769
+size 60493

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000635_512_0211.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000635_512_0211.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae2d219c621dd4add417a113d3c6c73b9710993c2371de4941b672da2169a195
+size 45008

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000636_512_0094.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000636_512_0094.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ca8819a2467bfd41e0c73333077fec0c6d0f0716b12c113602185924f7e1b2e
+size 71377

--- a/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000638_512_0335.jpg
+++ b/data/immersed_sounds_space/SDO/wavelength_sequence/20230101_000638_512_0335.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10c3016791e09c9c0a60fe8114ee37ff23891b128b3031b728217822b57d9dee
+size 72809


### PR DESCRIPTION
Hi @kaedonkers 

Wanting to merge in some stuff I created mostly over course of weekend, so it can be reusable future resource.
*Chances are quite high that future NASA Space Apps challenges relating to spacewx can reuse these*

This PR comprises:
* Some imagery data from Solar Dynamics Observatory (SDO)
* Some updates to README.md to
  * expose these resources ^^^
  * add some outcome links
  * make my creche ideas more explicit, in case can be reused for future Space Apps challenges
  * clarify the bootcamp thing we discussed before

Points to note
* imagery isn't huge - ~11.6 MB - but as binary data I've stored using Git LFS to avoid bloating this repo
* the script is a ~heavily derived work of an original script from NASA ([at bottom of this page](https://sdo.gsfc.nasa.gov/data/bestpractice.php)) without a clear licence
  * I *think* it's  OK, given some words re NASA's intention for reuse of data - see more on my rationale in commit message for 
abddc39
  * But want to flag this up to you explicitly!

Closes GH-3